### PR TITLE
fix failing test should_have_correct_address

### DIFF
--- a/protocol/src/contract/mod.rs
+++ b/protocol/src/contract/mod.rs
@@ -236,7 +236,7 @@ mod test {
 
         assert_eq!(
             refund.cash_address(),
-            "bitcoincash:prmnwxmmaq58h22jt7qrjmutnkrmrfm4j57zy4cf45"
+            "bchtest:prmnwxmmaq58h22jt7qrjmutnkrmrfm4j56sqj67jg"
         );
     }
 }


### PR DESCRIPTION
The assertion was originally looking for a bch Mainnet address when the test was creating a bch Testnet address.

This pull request fix the test by comparing the generated address with a bch Testnet address.

note: use specific branch for this pull request instead of last pull request that was using main.